### PR TITLE
Scale game correctly

### DIFF
--- a/apricots/apricots.h
+++ b/apricots/apricots.h
@@ -39,6 +39,8 @@ const int MAP_H = GAME_HEIGHT / 32;
 const double GAME_SPEED = 0.5;
 const int TICK_INTERVAL = 20;
 const double PI = 3.141592;
+const int SCREEN_HEIGHT = 480;
+const int SCREEN_WIDTH = 640;
 
 // Datatypes
 

--- a/apricots/drawall.cpp
+++ b/apricots/drawall.cpp
@@ -197,24 +197,26 @@ void drawall(gamedata &g) {
   // Set screenheight
   int screenheight = 0;
   if (g.players == 1) {
+    // TODO where do these numbers come from?
     screenheight = clamp(GAME_HEIGHT, GAME_HEIGHT, 464);
   } else {
     screenheight = clamp(GAME_HEIGHT, GAME_HEIGHT, 224);
   }
   // Player 1
   {
-    int x1 = clamp(int(g.player1->x) - 308, 0, GAME_WIDTH - 640);
+    // TODO where do these numbers come from?
+    int x1 = clamp(int(g.player1->x) - 308, 0, GAME_WIDTH - SCREEN_WIDTH);
     int y1 = clamp(int(g.player1->y) - 54, 0, GAME_HEIGHT - screenheight);
     SDL_Rect srcrect;
     srcrect.x = x1;
     srcrect.y = y1;
-    srcrect.w = 640;
+    srcrect.w = SCREEN_WIDTH;
     srcrect.h = screenheight;
     SDL_BlitSurface(g.gamescreen, &srcrect, g.virtualscreen, NULL);
     SDL_Rect cliprect;
     cliprect.x = 0;
     cliprect.y = 0;
-    cliprect.w = 640;
+    cliprect.w = SCREEN_WIDTH;
     cliprect.h = screenheight;
     SDL_SetClipRect(g.virtualscreen, &cliprect);
     drawblits(g, x1, y1);
@@ -225,23 +227,24 @@ void drawall(gamedata &g) {
 
   // Player 2
   if (g.players == 2) {
-    int x2 = clamp(int(g.player2->x) - 308, 0, GAME_WIDTH - 640);
+    // TODO where do these numbers come from?
+    int x2 = clamp(int(g.player2->x) - 308, 0, GAME_WIDTH - SCREEN_WIDTH);
     int y2 = clamp(int(g.player2->y) - 54, 0, GAME_HEIGHT - 224);
     SDL_Rect srcrect;
     srcrect.x = x2;
     srcrect.y = y2;
-    srcrect.w = 640;
+    srcrect.w = SCREEN_WIDTH;
     srcrect.h = screenheight;
     SDL_Rect desrect;
     desrect.x = 0;
     desrect.y = 240;
-    desrect.w = 640;
+    desrect.w = SCREEN_WIDTH;
     desrect.h = screenheight;
     SDL_BlitSurface(g.gamescreen, &srcrect, g.virtualscreen, &desrect);
     SDL_Rect cliprect;
     cliprect.x = 0;
     cliprect.y = 240;
-    cliprect.w = 640;
+    cliprect.w = SCREEN_WIDTH;
     cliprect.h = screenheight;
     SDL_SetClipRect(g.virtualscreen, &cliprect);
     drawblits(g, x2, y2 - 240);
@@ -292,8 +295,8 @@ void drawall(gamedata &g) {
   SDL_Rect rect;
   rect.x = 0;
   rect.y = 0;
-  rect.w = 640;
-  rect.h = 480;
+  rect.w = SCREEN_WIDTH;
+  rect.h = SCREEN_HEIGHT;
   SDL_Texture *texture = SDL_CreateTextureFromSurface(g.renderer, g.virtualscreen);
   if (texture == NULL) {
     fprintf(stderr, "CreateTextureFromSurface failed: %s\n", SDL_GetError());

--- a/apricots/finish.cpp
+++ b/apricots/finish.cpp
@@ -68,8 +68,8 @@ void finish_game(gamedata &g) {
     SDL_Rect rect;
     rect.x = 0;
     rect.y = 0;
-    rect.w = 640;
-    rect.h = 480;
+    rect.w = SCREEN_WIDTH;
+    rect.h = SCREEN_HEIGHT;
     SDL_Texture *texture = SDL_CreateTextureFromSurface(g.renderer, g.virtualscreen);
     if (texture == NULL) {
       fprintf(stderr, "CreateTextureFromSurface failed: %s\n", SDL_GetError());

--- a/apricots/init.cpp
+++ b/apricots/init.cpp
@@ -25,15 +25,22 @@
 // Display setup (double buffered with two playfields)
 
 void setup_display(gamedata &g) {
-  SDL_Window *window = SDL_CreateWindow("Apricots", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 640, 480, 0);
+  SDL_Window *window =
+      SDL_CreateWindow("Apricots", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, SCREEN_WIDTH, SCREEN_HEIGHT,
+                       SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_MAXIMIZED | SDL_WINDOW_RESIZABLE);
 
-  g.renderer = SDL_CreateRenderer(window, -1, 0);
+  g.renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
   if (g.renderer == NULL) {
     fprintf(stderr, "Couldn't create renderer: %s\n", SDL_GetError());
     exit(1);
   }
 
-  g.virtualscreen = SDL_CreateRGBSurface(SDL_SWSURFACE, 640, 480, 8, 0, 0, 0, 0);
+  if (SDL_RenderSetLogicalSize(g.renderer, SCREEN_WIDTH, SCREEN_HEIGHT) != 0) {
+    fprintf(stderr, "Couldn't set logical resizing: %s\n", SDL_GetError());
+    exit(1);
+  }
+
+  g.virtualscreen = SDL_CreateRGBSurface(SDL_SWSURFACE, SCREEN_WIDTH, SCREEN_HEIGHT, 8, 0, 0, 0, 0);
   if (g.virtualscreen == NULL) {
     fprintf(stderr, "Couldn't set 640x480x8 virtual video mode: %s\n", SDL_GetError());
     exit(1);


### PR DESCRIPTION
- Tell SDL to scale our game to the size of the window
- Tell SDL to render in software (there are graphical glitches
  otherwise)
- Move all instances of 640 and 480 to a global const

Fixes #23