### PR TITLE
Switch to SDL_clamp

### DIFF
--- a/apricots/ai.cpp
+++ b/apricots/ai.cpp
@@ -79,9 +79,9 @@ void computer_ai(gamedata &g, plane &p, int &jx, int &jy, bool &jb) {
             ((p.y + 20.0 > g.gamemap.steepheight[px]) || (p.y + 20.0 > g.gamemap.steepheight[px + 1])))
           p.coms = 1;
         if ((p.d > 2) && (p.d < 8))
-          px = clamp(px - 1, 0, MAP_W * 2 - 1);
+          px = SDL_clamp(px - 1, 0, MAP_W * 2 - 1);
         if ((p.d > 10) && (p.d < 16))
-          px = clamp(px + 1, 0, MAP_W * 2 - 1);
+          px = SDL_clamp(px + 1, 0, MAP_W * 2 - 1);
         if (p.ys < 0.0) {
           if ((p.y + 5.0 > g.gamemap.smoothheight[px]) || (p.y + 5.0 > g.gamemap.smoothheight[px + 1]))
             p.coms = 1;
@@ -410,7 +410,7 @@ void computer_ai(gamedata &g, plane &p, int &jx, int &jy, bool &jb) {
             double d = sqrt(rx * rx + ry * ry);
             if (d < 100.0) {
               double smartsine = ((ry * g.dp().xs - rx * g.dp().ys) / (8.0 * GAME_SPEED) / d);
-              smartsine = clamp(smartsine, -1.0, 1.0);
+              smartsine = SDL_clamp(smartsine, -1.0, 1.0);
               double smartangle = asin(smartsine);
               double angle = atan2(rx, ry);
               int bogied = wrap((int(((angle - smartangle) / PI * 8.0) + 1.5)), 1, 17);

--- a/apricots/all.cpp
+++ b/apricots/all.cpp
@@ -298,12 +298,12 @@ void fire_guns(linkedlist<guntype> &gun, linkedlist<plane> &p, sampleio &sound, 
           // Rotate gun
           if ((gun().rotate == 0) && (dy > 0)) {
             double smartsine = (dy * p().xs + dx * p().ys) / (8.0 * GAME_SPEED * sqrt(dx * dx + dy * dy));
-            smartsine = clamp(smartsine, -1.0, 1.0);
+            smartsine = SDL_clamp(smartsine, -1.0, 1.0);
             double smartangle = asin(smartsine);
             int move = sign(int(((atan(dx / dy) + smartangle) * 8.0 / PI) + 4.5) - gun().d);
             if (move != 0) {
 
-              gun().d = clamp(gun().d + move, 1, 7);
+              gun().d = SDL_clamp(gun().d + move, 1, 7);
               b[gun().xpos].image = 162 + gun().d;
               gun().rotate = int(2 / GAME_SPEED);
             }

--- a/apricots/apricots.h
+++ b/apricots/apricots.h
@@ -522,3 +522,10 @@ void setup_map(map &, int, airbase *, bool *);
 void setup_planes(linkedlist<plane> &, linkedlist<planeclone> &, airbase *, int, info *, plane *&, plane *&);
 void switch_bad_default(const char *, const char *, int);
 void winnerbox(gamedata &, int, int, int, int);
+
+// compatibility macros
+
+#if !SDL_VERSION_ATLEAST(2,0,18)
+#warning "Old version of SDL2 detected, adding SDL_clamp macro from SDL2 2.0.18"
+#define SDL_clamp(x, a, b) ((x) < (a)) ? (a) : (((x) > (b)) ? (b) : (x))
+#endif

--- a/apricots/collide.cpp
+++ b/apricots/collide.cpp
@@ -36,7 +36,7 @@ void detect_collisions(gamedata &g) {
         g.p().ys = 0;
         g.p().s = 0.0;
 
-        int px = clamp(int((g.p().x + 24.0) / 32), 0, MAP_W - 1);
+        int px = SDL_clamp(int((g.p().x + 24.0) / 32), 0, MAP_W - 1);
         if ((g.gamemap.groundheight[px] == GAME_HEIGHT - 2) &&
 
             (g.p().y > GAME_HEIGHT - 21)) { // hits sea
@@ -136,7 +136,7 @@ void detect_collisions(gamedata &g) {
 
     case 2: {
       // towers
-      int ty = clamp(int(g.p().y), g.gamemap.b[x].y - g.gamemap.b[x].towersize * 16, int(g.p().y));
+      int ty = SDL_clamp(int(g.p().y), g.gamemap.b[x].y - g.gamemap.b[x].towersize * 16, int(g.p().y));
       if (g.images[197].collide(g.gamemap.b[x].x, ty, g.images[g.p().image + g.p().d], (int)g.p().x, (int)g.p().y)) {
         g.p().state = 2;
         g.p().land = 2;
@@ -144,7 +144,7 @@ void detect_collisions(gamedata &g) {
         g.p().ys = g.p().ys * 0.5;
         g.p().s = 0.0;
         // Calculate height of tower strike
-        int h = clamp(int((g.gamemap.b[x].y - g.p().y) / 16), 0, 100);
+        int h = SDL_clamp(int((g.gamemap.b[x].y - g.p().y) / 16), 0, 100);
         // Knock off score
         g.p().score -= 40 * (g.gamemap.b[x].towersize + 1 - h);
         killtower(g, g.gamemap.b[x], g.p().xs * 0.5, g.p().ys * 0.5, h, g.p().id);

--- a/apricots/drak.cpp
+++ b/apricots/drak.cpp
@@ -154,7 +154,7 @@ void fire_drakguns(gamedata &g, linkedlist<drakguntype> &drakgun, drakmstype &dr
             // Rotate drakgun
             if (drakgun().rotate == 0) {
               double smartsine = (dy * p().xs - dx * p().ys) / (8.0 * GAME_SPEED * sqrt(dx * dx + dy * dy));
-              smartsine = clamp(smartsine, -1.0, 1.0);
+              smartsine = SDL_clamp(smartsine, -1.0, 1.0);
               double smartangle = asin(smartsine);
               int targetd = wrap(int(((atan2(dy, -dx) - smartangle) * 8.0 / PI) + 13.5), 1, 17);
               int move = sign(wrap(targetd - drakgun().d, -7, 9));
@@ -267,9 +267,9 @@ void drak_main(gamedata &g) {
         }
         // Apply Brakes
         if (g.drakms.xs > 0.0) {
-          g.drakms.xs = clamp(g.drakms.xs - 0.5 * GAME_SPEED * GAME_SPEED, 0.0, 4.0 * GAME_SPEED);
+          g.drakms.xs = SDL_clamp(g.drakms.xs - 0.5 * GAME_SPEED * GAME_SPEED, 0.0, 4.0 * GAME_SPEED);
         } else {
-          g.drakms.xs = clamp(g.drakms.xs + 0.5 * GAME_SPEED * GAME_SPEED, -4.0 * GAME_SPEED, 0.0);
+          g.drakms.xs = SDL_clamp(g.drakms.xs + 0.5 * GAME_SPEED * GAME_SPEED, -4.0 * GAME_SPEED, 0.0);
         }
       } else {
         // Follow Target
@@ -285,13 +285,13 @@ void drak_main(gamedata &g) {
         if ((abs(dx) > stopd) && (g.drakms.movedelay == 0)) {
           // Accelerate
           g.drakms.xs =
-              clamp(g.drakms.xs + 0.5 * GAME_SPEED * GAME_SPEED * sign(dx), -4.0 * GAME_SPEED, 4.0 * GAME_SPEED);
+              SDL_clamp(g.drakms.xs + 0.5 * GAME_SPEED * GAME_SPEED * sign(dx), -4.0 * GAME_SPEED, 4.0 * GAME_SPEED);
         } else {
           // Apply Brakes
           if (g.drakms.xs > 0.0) {
-            g.drakms.xs = clamp(g.drakms.xs - 0.5 * GAME_SPEED * GAME_SPEED, 0.0, 4.0 * GAME_SPEED);
+            g.drakms.xs = SDL_clamp(g.drakms.xs - 0.5 * GAME_SPEED * GAME_SPEED, 0.0, 4.0 * GAME_SPEED);
           } else {
-            g.drakms.xs = clamp(g.drakms.xs + 0.5 * GAME_SPEED * GAME_SPEED, -4.0 * GAME_SPEED, 0.0);
+            g.drakms.xs = SDL_clamp(g.drakms.xs + 0.5 * GAME_SPEED * GAME_SPEED, -4.0 * GAME_SPEED, 0.0);
           }
         }
         // Target destroyed

--- a/apricots/drawall.cpp
+++ b/apricots/drawall.cpp
@@ -198,15 +198,15 @@ void drawall(gamedata &g) {
   int screenheight = 0;
   if (g.players == 1) {
     // TODO where do these numbers come from?
-    screenheight = clamp(GAME_HEIGHT, GAME_HEIGHT, 464);
+    screenheight = SDL_clamp(GAME_HEIGHT, GAME_HEIGHT, 464);
   } else {
-    screenheight = clamp(GAME_HEIGHT, GAME_HEIGHT, 224);
+    screenheight = SDL_clamp(GAME_HEIGHT, GAME_HEIGHT, 224);
   }
   // Player 1
   {
     // TODO where do these numbers come from?
-    int x1 = clamp(int(g.player1->x) - 308, 0, GAME_WIDTH - SCREEN_WIDTH);
-    int y1 = clamp(int(g.player1->y) - 54, 0, GAME_HEIGHT - screenheight);
+    int x1 = SDL_clamp(int(g.player1->x) - 308, 0, GAME_WIDTH - SCREEN_WIDTH);
+    int y1 = SDL_clamp(int(g.player1->y) - 54, 0, GAME_HEIGHT - screenheight);
     SDL_Rect srcrect;
     srcrect.x = x1;
     srcrect.y = y1;
@@ -228,8 +228,8 @@ void drawall(gamedata &g) {
   // Player 2
   if (g.players == 2) {
     // TODO where do these numbers come from?
-    int x2 = clamp(int(g.player2->x) - 308, 0, GAME_WIDTH - SCREEN_WIDTH);
-    int y2 = clamp(int(g.player2->y) - 54, 0, GAME_HEIGHT - 224);
+    int x2 = SDL_clamp(int(g.player2->x) - 308, 0, GAME_WIDTH - SCREEN_WIDTH);
+    int y2 = SDL_clamp(int(g.player2->y) - 54, 0, GAME_HEIGHT - 224);
     SDL_Rect srcrect;
     srcrect.x = x2;
     srcrect.y = y2;

--- a/apricots/fall.cpp
+++ b/apricots/fall.cpp
@@ -15,7 +15,7 @@ bool fall_collision(gamedata &g, falltype &fall) {
       break;
     case 1: // Shrapnel
     {
-      int px = clamp(int((fall.x + 18.0) / 32), 0, MAP_W - 1);
+      int px = SDL_clamp(int((fall.x + 18.0) / 32), 0, MAP_W - 1);
       if ((g.gamemap.groundheight[px] == GAME_HEIGHT - 2) && (fall.y > GAME_HEIGHT - 11)) { // hits sea
         firetype splash;
         splash.x = int(fall.x) - 5;
@@ -38,7 +38,7 @@ bool fall_collision(gamedata &g, falltype &fall) {
       if (fall.type == 3)
         fall.x -= 5;
       {
-        int px = clamp(int((fall.x + 24.0) / 32), 0, MAP_W - 1);
+        int px = SDL_clamp(int((fall.x + 24.0) / 32), 0, MAP_W - 1);
         if ((g.gamemap.groundheight[px] == GAME_HEIGHT - 2) && (fall.y > GAME_HEIGHT - 21)) { // hits sea
           firetype splash;
           splash.x = int(fall.x);
@@ -153,10 +153,10 @@ bool fall_collision(gamedata &g, falltype &fall) {
 
     case 2: // towers
     {
-      int ty = clamp(int(fall.y), g.gamemap.b[x].y - g.gamemap.b[x].towersize * 16, int(fall.y));
+      int ty = SDL_clamp(int(fall.y), g.gamemap.b[x].y - g.gamemap.b[x].towersize * 16, int(fall.y));
       if (g.images[197].collide(g.gamemap.b[x].x, ty, g.images[fall.image], (int)fall.x, (int)fall.y)) {
         // Calculate height of tower strike
-        int h = clamp(int((g.gamemap.b[x].y - fall.y) / 16), 0, 100);
+        int h = SDL_clamp(int((g.gamemap.b[x].y - fall.y) / 16), 0, 100);
         // Find which plane (if any) the fall belongs to
         if (fall.side > 0) {
           g.p.reset();

--- a/apricots/game.cpp
+++ b/apricots/game.cpp
@@ -115,7 +115,7 @@ void act(gamedata &g, int jx, int jy, bool jb) {
 
     case 1: // Taking off plane
       if (jy == -1) {
-        g.p().s = clamp(g.p().s + 0.3 * GAME_SPEED * GAME_SPEED, 0.0, 6.0 * GAME_SPEED);
+        g.p().s = SDL_clamp(g.p().s + 0.3 * GAME_SPEED * GAME_SPEED, 0.0, 6.0 * GAME_SPEED);
       }
       // Take off plane
       if ((jx == -1) && (g.p().s > 2.0 * GAME_SPEED) && (g.base[g.p().side].planed == 13)) {
@@ -155,9 +155,9 @@ void act(gamedata &g, int jx, int jy, bool jb) {
           if ((g.p().s > 6.0 * GAME_SPEED) && (jy != -1)) {
             acceleration -= 0.3 * GAME_SPEED * GAME_SPEED;
           }
-          g.p().s = clamp(g.p().s + acceleration, 0.0, 12.0 * GAME_SPEED);
+          g.p().s = SDL_clamp(g.p().s + acceleration, 0.0, 12.0 * GAME_SPEED);
         } else {
-          g.p().s = clamp(g.p().s + acceleration, 0.0, 6.0 * GAME_SPEED);
+          g.p().s = SDL_clamp(g.p().s + acceleration, 0.0, 6.0 * GAME_SPEED);
         }
       }
       // Stealth Controls
@@ -251,7 +251,7 @@ void act(gamedata &g, int jx, int jy, bool jb) {
     }
     // Recover from Stall
     if ((g.p().ys > 3.0 * GAME_SPEED) && (g.p().d == 9)) {
-      g.p().s = clamp(g.p().ys, 3.0 * GAME_SPEED, 6.0 * GAME_SPEED);
+      g.p().s = SDL_clamp(g.p().ys, 3.0 * GAME_SPEED, 6.0 * GAME_SPEED);
       g.p().state = 0;
       g.p().xs = g.p().s * g.xmove[g.p().d];
       g.p().ys = g.p().s * g.ymove[g.p().d];

--- a/apricots/setup.cpp
+++ b/apricots/setup.cpp
@@ -696,10 +696,10 @@ void draw_dither(SDL_Surface *gamescreen, int xbox, int ybox, int w, int h) {
   if (SDL_MUSTLOCK(gamescreen) != 0)
     SDL_LockSurface(gamescreen);
   Uint8 *pixels = (Uint8 *)gamescreen->pixels;
-  int xstart = clamp(xbox, 0, GAME_WIDTH);
-  int xend = clamp(xbox + w, 0, GAME_WIDTH);
-  int ystart = clamp(ybox, 0, GAME_HEIGHT);
-  int yend = clamp(ybox + h, 0, GAME_HEIGHT);
+  int xstart = SDL_clamp(xbox, 0, GAME_WIDTH);
+  int xend = SDL_clamp(xbox + w, 0, GAME_WIDTH);
+  int ystart = SDL_clamp(ybox, 0, GAME_HEIGHT);
+  int yend = SDL_clamp(ybox + h, 0, GAME_HEIGHT);
   for (int x = xstart; x < xend; x++) {
     for (int y = ystart; y < yend; y++) {
       if (x < 0 || x >= GAME_WIDTH || y < 0 || y >= GAME_HEIGHT) {

--- a/apricots/shape.cpp
+++ b/apricots/shape.cpp
@@ -306,29 +306,13 @@ bool shape ::writefile(char *filename) {
   return true;
 }
 
-// Maximization function (for collision detection)
-
-int shape ::max(int a, int b) {
-  if (a > b)
-    return a;
-  return b;
-}
-
-// Minimization function (for collision detection)
-
-int shape ::min(int a, int b) {
-  if (a < b)
-    return a;
-  return b;
-}
-
 // Shape collision detection routine
 // Checks if the shape at x,y collides with another shape s at sx,sy
 // NB assumes BYTESPERPIXEL == 1
 
 bool shape ::collide(int x, int y, const shape &s, int sx, int sy) {
-  for (int cx = max(x, sx); cx < min(x + width, sx + s.width); cx++) {
-    for (int cy = max(y, sy); cy < min(y + height, sy + s.height); cy++) {
+  for (int cx = SDL_max(x, sx); cx < SDL_min(x + width, sx + s.width); cx++) {
+    for (int cy = SDL_max(y, sy); cy < SDL_min(y + height, sy + s.height); cy++) {
       if ((buffer[cx - x + width * (cy - y)] != 0) && (s.buffer[cx - sx + s.width * (cy - sy)] != 0)) {
         return true;
       }

--- a/apricots/shape.h
+++ b/apricots/shape.h
@@ -16,8 +16,6 @@ private:
   int width;
   int height;
   char *buffer;
-  int max(int, int);
-  int min(int, int);
 
 public:
   shape();


### PR DESCRIPTION
Also remove max/min private functions from shape

SDL introduced this macro a few years ago and I think that's what's caused this bug (despite there being no changes to Apricots in the mean time). I don't quite understand *why* it breaks as std::clamp work the exact same way.

Relevant SDL commits:
- https://github.com/libsdl-org/SDL/commit/35c1bbfa49b1247c2c6240f7f95871f3b3331874
- https://github.com/libsdl-org/SDL/commit/fbc364908a4fd4644e96377ed488811f025cf36b

Fixes #41