### PR TITLE
Correctly limit tower height calculations

### DIFF
--- a/apricots/collide.cpp
+++ b/apricots/collide.cpp
@@ -132,7 +132,7 @@ void detect_collisions(gamedata &g) {
 
     case 2: {
       // towers
-      int ty = g.gamemap.b[x].y - g.gamemap.b[x].towersize * 16;
+      int ty = max(int(g.p().y), g.gamemap.b[x].y - g.gamemap.b[x].towersize * 16);
       if (g.images[197].collide(g.gamemap.b[x].x, ty, g.images[g.p().image + g.p().d], (int)g.p().x, (int)g.p().y)) {
         g.p().state = 2;
         g.p().land = plane::LandingState::FLYING;

--- a/apricots/fall.cpp
+++ b/apricots/fall.cpp
@@ -137,7 +137,7 @@ bool fall_collision(gamedata &g, falltype &fall) {
 
     case 2: // towers
     {
-      int ty = g.gamemap.b[x].y - g.gamemap.b[x].towersize * 16;
+      int ty = max(int(fall.y), g.gamemap.b[x].y - g.gamemap.b[x].towersize * 16);
       if (g.images[197].collide(g.gamemap.b[x].x, ty, g.images[fall.image], (int)fall.x, (int)fall.y)) {
         // Calculate height of tower strike
         int h = clamp(int((g.gamemap.b[x].y - fall.y) / 16), 0, 100);


### PR DESCRIPTION
These lines previously had calls to "limit" (which was a clamp implementation) but they were of the form `limit(v, lo, v);` which is very confusing! Replacing `limit` with `clamp` caused errors so I decided to remove the calls and just use the `lo` value.

This worked™ except it also allowed planes to fly through towers without hitting them. Going back and re-reading the v0.2.6 source code made me realise that `limit` was being used like `max`, so we now call `max`.

Fixes #50 