### PR TITLE
End screen waits for user input before qutting

### DIFF
--- a/apricots/apricots.h
+++ b/apricots/apricots.h
@@ -42,6 +42,7 @@ const int TICK_INTERVAL = 20;
 const double PI = 3.141592;
 const int SCREEN_HEIGHT = 480;
 const int SCREEN_WIDTH = 640;
+const int QUIT_WAIT_MS = 2000;
 
 // Datatypes
 

--- a/apricots/finish.cpp
+++ b/apricots/finish.cpp
@@ -78,9 +78,15 @@ void finish_game(gamedata &g) {
     SDL_RenderCopy(g.renderer, texture, &rect, NULL);
     SDL_RenderPresent(g.renderer);
     g.sound.play(SOUND_FINISH);
-    // Wait 4 Seconds
-    int then = time(0);
-    while (time(0) - then < 4) {
+
+    SDL_Delay(QUIT_WAIT_MS);
+
+    SDL_Event event;
+    while (true) {
+      SDL_WaitEvent(&event);
+      if (event.type == SDL_QUIT || event.type == SDL_KEYDOWN) {
+        break;
+      }
     }
     SDL_DestroyTexture(texture);
   }


### PR DESCRIPTION
After a 2 second delay, wait for key press before quitting so no one misses the win/lose screen